### PR TITLE
use blocks_without_votes and solana-common source to speed up

### DIFF
--- a/orca-whirlpool/Cargo.toml
+++ b/orca-whirlpool/Cargo.toml
@@ -14,7 +14,7 @@ prost = "0.11"
 bs58 = "0.5.0"
 borsh = { version = "1.5.0", features = ["derive"] }
 substreams = { workspace = true }
-substreams-solana = { workspace = true }
+substreams-solana = { workspace = true, version = "0.13.0" }
 substreams-entity-change = { workspace = true }
 substreams-solana-program-instructions = { workspace = true }
 derive_deserialize = { path = "../derive_deserialize" }

--- a/orca-whirlpool/src/lib.rs
+++ b/orca-whirlpool/src/lib.rs
@@ -39,7 +39,7 @@ fn map_block(block: Block) -> Result<Events, substreams::errors::Error> {
     let mut data: Vec<Event> = Vec::new();
 
     for confirmed_txn in block.transactions() {
-        for instruction in confirmed_txn.instructions().into_iter() {
+        for instruction in confirmed_txn.walk_instructions() {
             if instruction.program_id().to_string() != constants::ORCA_WHIRLPOOL {
                 continue;
             }

--- a/orca-whirlpool/substreams.yaml
+++ b/orca-whirlpool/substreams.yaml
@@ -5,6 +5,8 @@ package:
 
 imports:
   entity: https://github.com/streamingfast/substreams-sink-entity-changes/releases/download/v1.3.2/substreams-sink-entity-changes-v1.3.2.spkg
+  solanacommon: https://spkg.io/streamingfast/solana-common-v0.2.0.spkg
+
 
 protobuf:
   files:
@@ -21,8 +23,12 @@ modules:
   - name: map_block
     kind: map
     initialBlock: 126272054
+    blockFilter:
+      module: solanacommon:program_ids_without_votes
+      query:
+        string: program:whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc
     inputs:
-      - source: sf.solana.type.v1.Block
+      - map: solanacommon:blocks_without_votes
     output:
       type: proto:messari.orca_whirlpool.v1.Events
 


### PR DESCRIPTION
Use solana foundational module: https://substreams.dev/streamingfast/solana-common/v0.2.0

* change input to 'blocks_without_votes'
* add blockFilter to only match blocks with program ID: `whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc`

Since the solana foundational module (maps and indexed) are already cached on StreamingFast's substreams servers, this gives a good performance improvement (about 4x)

Data output is identical

