### PR TITLE
Few updates and improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = []
 
 [workspace.dependencies]
 substreams = "^0.5.21"
-substreams-solana = { git = "https://github.com/streamingfast/substreams-solana", branch = "master" }
+substreams-solana = { version = "0.13.0" }
 substreams-entity-change = "1.3.2"
 substreams-solana-program-instructions = "0.1"
 

--- a/orca-whirlpool/Cargo.toml
+++ b/orca-whirlpool/Cargo.toml
@@ -14,7 +14,7 @@ prost = "0.11"
 bs58 = "0.5.0"
 borsh = { version = "1.5.0", features = ["derive"] }
 substreams = { workspace = true }
-substreams-solana = { workspace = true, version = "0.13.0" }
+substreams-solana = { workspace = true }
 substreams-entity-change = { workspace = true }
 substreams-solana-program-instructions = { workspace = true }
 derive_deserialize = { path = "../derive_deserialize" }

--- a/orca-whirlpool/src/constants.rs
+++ b/orca-whirlpool/src/constants.rs
@@ -1,3 +1,5 @@
+use substreams_solana::b58;
+
 pub struct DiscriminatorConstants;
 
 impl DiscriminatorConstants {
@@ -20,4 +22,4 @@ impl DiscriminatorConstants {
     pub const _SWAP_V2: [u8; 8] = [43, 4, 237, 11, 26, 201, 30, 98];
 }
 
-pub const ORCA_WHIRLPOOL: &str = "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc";
+pub const ORCA_WHIRLPOOL: [u8; 32] = b58!("whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc");

--- a/orca-whirlpool/src/lib.rs
+++ b/orca-whirlpool/src/lib.rs
@@ -40,7 +40,7 @@ fn map_block(block: Block) -> Result<Events, substreams::errors::Error> {
 
     for confirmed_txn in block.transactions() {
         for instruction in confirmed_txn.walk_instructions() {
-            if instruction.program_id().to_string() != constants::ORCA_WHIRLPOOL {
+            if instruction.program_id() != constants::ORCA_WHIRLPOOL {
                 continue;
             }
 

--- a/orca-whirlpool/substreams.yaml
+++ b/orca-whirlpool/substreams.yaml
@@ -5,8 +5,7 @@ package:
 
 imports:
   entity: https://github.com/streamingfast/substreams-sink-entity-changes/releases/download/v1.3.2/substreams-sink-entity-changes-v1.3.2.spkg
-  solanacommon: https://spkg.io/streamingfast/solana-common-v0.2.0.spkg
-
+  solana: https://spkg.io/streamingfast/solana-common-v0.2.0.spkg
 
 protobuf:
   files:
@@ -24,11 +23,11 @@ modules:
     kind: map
     initialBlock: 126272054
     blockFilter:
-      module: solanacommon:program_ids_without_votes
+      module: solana:program_ids_without_votes
       query:
         string: program:whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc
     inputs:
-      - map: solanacommon:blocks_without_votes
+      - map: solana:blocks_without_votes
     output:
       type: proto:messari.orca_whirlpool.v1.Events
 
@@ -37,6 +36,6 @@ modules:
     inputs:
       - map: map_block
     output:
-      type: proto:substreams.entity.v1.EntityChanges
+      type: proto:sf.substreams.sink.entity.v1.EntityChanges
 
 network: solana


### PR DESCRIPTION
- It's better to perform `account/program_id` comparison against `[u8; 32]` avoiding having to perform a base58 encode on each comparison.
- Renamed `solanacommon` to simply `solana`
- Fixed output module Protobuf's message ID to use correct type on `graph_out`.
- Set `substreams-solana` dependency version on workspace level Cargo.toml.