### PR TITLE
[Phase 4]; Orca Whirlpool; Add v2 Orca instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Solana Subgraphs
+
+This repository contains subgraphs for indexing and querying data from various Solana protocols. Currently, it includes a subgraph for the Orca Whirlpool protocol.
+
+## Overview
+
+Solana Subgraphs use [The Graph](https://thegraph.com/) protocol to index and query blockchain data efficiently. This project leverages Substreams technology to process Solana blockchain data and generate entities for Graph Protocol indexing.
+
+## Subgraphs
+
+### Orca Whirlpool
+
+The Orca Whirlpool subgraph indexes data from the Orca Whirlpool protocol on the Solana blockchain. It processes transactions related to liquidity pools, swaps, deposits, and withdrawals.
+
+Key features:
+- Indexes pool creation and updates
+- Tracks liquidity deposits and withdrawals
+- Records swap events
+- Maintains cumulative statistics
+
+For more details on the Orca Whirlpool subgraph, refer to its specific README: [Orca Whirlpool README](./orca-whirlpool/README.md)
+
+
+## Getting Started
+
+To build and run a subgraph:
+
+1. Navigate to the subgraph directory (e.g., `cd orca-whirlpool`)
+2. Install dependencies: `cargo build`
+3. Generate protocol buffers: `cargo protogen`
+4. Build the subgraph: `cargo build --target wasm32-unknown-unknown --release`
+5. Run the substream: `cargo stream`
+
+## Development
+
+To add support for new instructions or modify existing ones, refer to the "Adding Support for New Instructions" section in the Orca Whirlpool README.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/orca-whirlpool/Cargo.toml
+++ b/orca-whirlpool/Cargo.toml
@@ -16,5 +16,4 @@ borsh = { version = "1.5.0", features = ["derive"] }
 substreams = { workspace = true }
 substreams-solana = { workspace = true }
 substreams-entity-change = { workspace = true }
-substreams-solana-program-instructions = { workspace = true }
 derive_deserialize = { path = "../derive_deserialize" }

--- a/orca-whirlpool/Makefile
+++ b/orca-whirlpool/Makefile
@@ -6,11 +6,11 @@ build:
 
 .PHONY: stream
 stream: build
-	substreams run -e $(ENDPOINT) substreams.yaml map_pools -s 124288454 -t +1000
+	substreams run -e $(ENDPOINT) substreams.yaml map_swaps -s 126272128 -t +1
 
 .PHONY: gui
 gui: build
-	substreams gui substreams.yaml graph_out -s 124152351 --production-mode
+	substreams gui substreams.yaml map_swaps -s 126272128 -t +1 --production-mode
 
 .PHONY: protogen
 protogen:

--- a/orca-whirlpool/README.md
+++ b/orca-whirlpool/README.md
@@ -1,58 +1,135 @@
-# Orca Whirlpool Substream
+# Orca-Whirlpool Substream
+
+This substream processes Orca Whirlpool transactions on the Solana blockchain, extracting and organizing data related to liquidity pools, swaps, deposits, and withdrawals.
 
 ## Overview
 
-This project is a Substream for the Orca Whirlpool protocol on the Solana blockchain. It processes and indexes data from Orca Whirlpool, providing structured and easily queryable information about liquidity pools, swaps, deposits, and withdrawals.
+The Orca-Whirlpool substream is designed to:
 
-## Features
+1. Map and process Orca Whirlpool transactions
+2. Extract data for pools, deposits, withdrawals, and swaps
+3. Store and update cumulative statistics
+4. Generate entity changes for downstream consumers (e.g., Graph Protocol) to enable efficient data querying and analysis
 
-- Tracks initialization of new liquidity pools
-- Monitors liquidity additions and removals
-- Indexes swap events, including two-hop swaps
-- Calculates daily usage metrics and pool statistics
-- Provides cumulative user counts and total pool counts
+## Key Components
 
-## Project Structure
+### Modules
 
-The project is primarily written in Rust and uses the Substreams framework. Here's an overview of the main components:
+1. `map_block`: Processes raw Solana blocks to extract Orca Whirlpool events
+2. `map_pools`: Extracts and processes pool-related data
+3. `map_deposits`: Processes deposit (increase liquidity) events
+4. `map_withdraws`: Processes withdrawal (decrease liquidity) events
+5. `map_swaps`: Processes swap events
+6. `graph_out`: Generates entity changes for the Graph protocol
 
-- `src/`: Contains the main Rust source code
-  - `modules/`: Individual substream modules for different functionalities
-  - `instructions/`: Definitions for Orca Whirlpool instructions
-  - `pb/`: Protocol Buffer definitions
-  - `db.rs`: Database handling functions
-  - `key_store.rs`: Key management for data storage
-  - `lib.rs`: Main library file
-  - `orca_instructions.rs`: Orca-specific instruction handling
-- `proto/`: Protocol Buffer definitions
-- `substreams.yaml`: Substreams configuration file
-- `Cargo.toml`: Rust package configuration
+### Instructions
 
-## Key Modules
+The substream handles various Orca Whirlpool instructions, including:
 
-1. `map_block`: Processes raw block data and extracts relevant events
-2. `map_pools`: Tracks new pool initializations
-3. `map_deposits` and `map_withdraws`: Processes liquidity additions and removals
-4. `map_swaps`: Indexes swap events
-5. `store_*` modules: Various modules for storing and updating metrics
+- Initialize Pool (V1 and V2)
+- Increase Liquidity (V1 and V2)
+- Decrease Liquidity (V1 and V2)
+- Swap (V1 and V2)
+- Two Hop Swap (V1 and V2)
 
-## Setup and Usage
+### Data Structures
 
-1. Ensure you have Rust and the `wasm32-unknown-unknown` target installed.
-2. Install the Substreams CLI tool.
-3. Build the project:
-   ```
-   cargo build --target wasm32-unknown-unknown --release
-   ```
-4. Pack the Substream:
-   ```
-   substreams pack ./substreams.yaml
-   ```
-5. Run the Substream:
-   ```
-   substreams run -e mainnet.sol.streamingfast.io:443 substreams.yaml map_pools -s 124288454 -t +1000
-   ```
+The main data structures are defined in the `output.proto` file.
 
-## Configuration
+### Stores
 
-The main configuration file is `substreams.yaml`. It defines the modules, their dependencies, and the initial block for processing.
+The substream uses several stores to maintain state:
+
+- `store_pools`: Stores pool data
+- `store_deposits`: Stores deposit data
+- `store_withdraws`: Stores withdrawal data
+- `store_swaps`: Stores swap data
+- `store_unique_users`: Tracks unique users
+- `store_cumulative_users`: Maintains cumulative user count
+- `store_total_pool_count`: Tracks total pool count
+- `store_pool_balances`: Stores pool token balances
+- `store_pool_liquidity`: Tracks pool liquidity
+
+## Usage
+
+To build and run the substream:
+
+```bash
+cargo protogen
+cargo build
+cargo stream
+```
+
+## Adding Support for New Instructions
+
+To add support for new Orca Whirlpool instructions:
+
+1. Update the `src/pb/orca.whirlpool.v1.rs` file to include the new instruction definition.
+2. Modify the `map_block` function in `src/lib.rs` to handle the new instruction type.
+3. Create a new mapping function in the appropriate module (e.g., `map_pools.rs`, `map_deposits.rs`, etc.) to process the new instruction data.
+4. Update the relevant stores to accommodate any new data fields.
+5. Modify the `graph_out` module to include the new data in the entity changes if necessary.
+
+## Including Swaps, Deposits, and Withdrawals
+
+To include swaps, deposits, and withdrawals in the substream output:
+
+1. Open the `src/graph_out.rs` file.
+2. Locate the commented-out sections for swaps, deposits, and withdrawals.
+3. Uncomment the relevant code blocks to include these entities in the output.
+4. Ensure that the corresponding stores (e.g., `store_swaps`, `store_deposits`, `store_withdraws`) are properly populated in their respective mapping functions.
+
+
+### Graph
+
+```mermaid
+graph TD;
+  map_block[map: map_block];
+  solana:blocks_without_votes --> map_block;
+  map_pools[map: map_pools];
+  map_block --> map_pools;
+  store_pools[store: store_pools];
+  map_pools --> store_pools;
+  map_deposits[map: map_deposits];
+  map_block --> map_deposits;
+  store_pools --> map_deposits;
+  store_deposits[store: store_deposits];
+  map_block --> store_deposits;
+  map_withdraws[map: map_withdraws];
+  map_block --> map_withdraws;
+  store_pools --> map_withdraws;
+  store_withdraws[store: store_withdraws];
+  map_block --> store_withdraws;
+  map_swaps[map: map_swaps];
+  map_block --> map_swaps;
+  store_pools --> map_swaps;
+  store_swaps[store: store_swaps];
+  map_swaps --> store_swaps;
+  store_unique_users[store: store_unique_users];
+  map_block --> store_unique_users;
+  store_cumulative_users[store: store_cumulative_users];
+  store_unique_users -- deltas --> store_cumulative_users;
+  store_total_pool_count[store: store_total_pool_count];
+  store_pools -- deltas --> store_total_pool_count;
+  store_pool_balances[store: store_pool_balances];
+  map_deposits --> store_pool_balances;
+  map_withdraws --> store_pool_balances;
+  map_swaps --> store_pool_balances;
+  store_pool_liquidity[store: store_pool_liquidity];
+  map_deposits --> store_pool_liquidity;
+  map_withdraws --> store_pool_liquidity;
+  graph_out[map: graph_out];
+  sf.substreams.v1.Clock[source: sf.substreams.v1.Clock] --> graph_out;
+  map_pools --> graph_out;
+  store_pools --> graph_out;
+  store_cumulative_users -- deltas --> graph_out;
+  store_total_pool_count -- deltas --> graph_out;
+  store_pool_balances -- deltas --> graph_out;
+  store_pool_liquidity -- deltas --> graph_out;
+  solana:blocks_without_votes[map: solana:blocks_without_votes];
+  sf.solana.type.v1.Block[source: sf.solana.type.v1.Block] --> solana:blocks_without_votes;
+  solana:blocks_without_votes --> solana:program_ids_without_votes;
+  solana:filtered_transactions_without_votes[map: solana:filtered_transactions_without_votes];
+  solana:filtered_transactions_without_votes:params[params] --> solana:filtered_transactions_without_votes;
+  solana:blocks_without_votes --> solana:filtered_transactions_without_votes;
+```

--- a/orca-whirlpool/proto/output.proto
+++ b/orca-whirlpool/proto/output.proto
@@ -109,10 +109,18 @@ message Event {
   oneof type {
     InitializePool initialize_pool = 10;
     InitializePoolV2 initialize_pool_v2 = 11;
+    
     IncreaseLiquidity increase_liquidity = 20;
+    IncreaseLiquidityV2 increase_liquidity_v2 = 21;
+    
     DecreaseLiquidity decrease_liquidity = 30;
+    DecreaseLiquidityV2 decrease_liquidity_v2 = 31;
+    
     TwoHopSwap two_hop_swap = 40;
+    TwoHopSwapV2 two_hop_swap_v2 = 41;
+    
     OrcaSwap swap = 50;
+    OrcaSwapV2 swap_v2 = 51;
   }
 
   uint64 slot = 100;
@@ -206,6 +214,44 @@ message IncreaseLiquidity {
   }
 }
 
+message IncreaseLiquidityV2 {
+  Instruction instruction = 1;
+  Accounts accounts = 2;
+
+  message Instruction {
+      string liquidity_amount = 1;
+      
+      string token_max_a = 2;
+      string token_max_b = 3;
+
+      optional string amount_a = 4;
+      optional string amount_a_pre = 5;
+      optional string amount_a_post = 6;
+
+      optional string amount_b = 7;
+      optional string amount_b_pre = 8;
+      optional string amount_b_post = 9;
+  }
+
+  message Accounts {
+    string whirlpool = 1;
+    string token_program_a = 2;
+    string token_program_b = 3;
+    string memo_program = 4;
+    string position_authority = 5;
+    string position = 6;
+    string position_token_account = 7;
+    string token_mint_a = 8;
+    string token_mint_b = 9;
+    string token_owner_account_a = 10;
+    string token_owner_account_b = 11;
+    string token_vault_a = 12;
+    string token_vault_b = 13;
+    string tick_array_lower = 14;
+    string tick_array_upper = 15;
+  }
+}
+
 message DecreaseLiquidity {
   Instruction instruction = 1;
   Accounts accounts = 2;
@@ -238,6 +284,45 @@ message DecreaseLiquidity {
     string token_vault_b = 9;
     string tick_array_lower = 10;
     string tick_array_upper = 11;
+  }
+}
+
+message DecreaseLiquidityV2 {
+  Instruction instruction = 1;
+  Accounts accounts = 2;
+
+  message Instruction {
+      string liquidity_amount = 1;
+      
+      string token_min_a = 2;
+      string token_min_b = 3;
+      
+      optional string amount_a = 4;
+      optional string amount_a_pre = 5;
+      optional string amount_a_post = 6;
+
+      optional string amount_b = 7;
+      optional string amount_b_pre = 8;
+      optional string amount_b_post = 9;
+
+  }
+
+  message Accounts {
+    string whirlpool = 1;
+    string token_program_a = 2;
+    string token_program_b = 3;
+    string memo_program = 4;
+    string position_authority = 5;
+    string position = 6;
+    string position_token_account = 7;
+    string token_mint_a = 8;
+    string token_mint_b = 9;
+    string token_owner_account_a = 10;
+    string token_owner_account_b = 11;
+    string token_vault_a = 12;
+    string token_vault_b = 13;
+    string tick_array_lower = 14;
+    string tick_array_upper = 15;
   }
 }
 
@@ -300,6 +385,68 @@ message TwoHopSwap {
   }
 }
 
+message TwoHopSwapV2 {
+  Instruction instruction = 1;
+  Accounts accounts = 2;
+
+  message Instruction {
+    string amount = 1;
+    
+    optional string amount_a_one = 2;
+    optional string amount_b_one = 3;
+
+    optional string amount_a_one_pre = 4;
+    optional string amount_a_one_post = 5;
+
+    optional string amount_b_one_pre = 6;
+    optional string amount_b_one_post = 7;
+    
+    optional string amount_a_two = 8;
+    optional string amount_b_two = 9;
+
+    optional string amount_a_two_pre = 10;
+    optional string amount_a_two_post = 11;
+
+    optional string amount_b_two_pre = 12;
+    optional string amount_b_two_post = 13;
+
+    string other_amount_threshold = 14;
+    
+    bool amount_specified_is_input = 15;
+    bool a_to_b_one = 16;
+    bool a_to_b_two = 17;
+    
+    string sqrt_price_limit_one = 18;
+    string sqrt_price_limit_two = 19;
+  }
+  message Accounts {
+    string whirlpool_one = 1;
+    string whirlpool_two = 2;
+    string token_mint_input = 3;
+    string token_mint_intermediate = 4;
+    string token_mint_output = 5;
+    string token_program_input = 6;
+    string token_program_intermediate = 7;
+    string token_program_output = 8;
+    string token_owner_account_input = 9;
+    string token_vault_one_input = 10;
+    string token_vault_one_intermediate = 11;
+    string token_vault_two_intermediate = 12;
+    string token_vault_two_output = 13;
+    string token_owner_account_output = 14;
+    string token_authority = 15;
+    string tick_array_one0 = 16;
+    string tick_array_one1 = 17;
+    string tick_array_one2 = 18;
+    string tick_array_two0 = 19;
+    string tick_array_two1 = 20;
+    string tick_array_two2 = 21;
+    string oracle_one = 22;
+    string oracle_two = 23;
+    string memo_program = 24;
+  }
+}
+
 message OrcaSwap {
   Instruction instruction = 1;
   Accounts accounts = 2;
@@ -335,5 +482,48 @@ message OrcaSwap {
     string tick_array_1 = 9;
     string tick_array_2 = 10;
     string oracle = 11;
+  }
+}
+
+
+message OrcaSwapV2 {
+  Instruction instruction = 1;
+  Accounts accounts = 2;
+
+  message Instruction {
+    string amount = 1;
+    
+    optional string amount_a_pre = 2;
+    optional string amount_a_post = 3;
+
+    optional string amount_b_pre = 4;
+    optional string amount_b_post = 5;
+
+    optional string amount_a = 6;
+    optional string amount_b = 7;
+    
+    string other_amount_threshold = 8;
+    string sqrt_price_limit = 9;
+    
+    bool amount_specified_is_input = 10;
+    bool a_to_b = 11;
+  }
+
+  message Accounts {
+    string token_program_a = 1;
+    string token_program_b = 2;
+    string memo_program = 3;
+    string token_authority = 4;
+    string whirlpool = 5;
+    string token_mint_a = 6;
+    string token_mint_b = 7;
+    string token_owner_account_a = 8;
+    string token_vault_a = 9;
+    string token_owner_account_b = 10;
+    string token_vault_b = 11;
+    string tick_array_0 = 12;
+    string tick_array_1 = 13;
+    string tick_array_2 = 14;
+    string oracle = 15;
   }
 }

--- a/orca-whirlpool/src/constants.rs
+++ b/orca-whirlpool/src/constants.rs
@@ -15,11 +15,12 @@ impl DiscriminatorConstants {
     // V2
     pub const INITIALIZE_POOL_V2: [u8; 8] = [207, 45, 87, 242, 27, 63, 204, 67];
 
-    // TODO: Add these v2 instructions
-    pub const _DECREASE_LIQUIDITY_V2: [u8; 8] = [58, 127, 188, 62, 79, 82, 196, 96];
-    pub const _INCREASE_LIQUIDITY_V2: [u8; 8] = [133, 29, 89, 223, 69, 238, 176, 10];
-    pub const _TWO_HOP_SWAP_V2: [u8; 8] = [186, 143, 209, 29, 254, 2, 194, 117];
-    pub const _SWAP_V2: [u8; 8] = [43, 4, 237, 11, 26, 201, 30, 98];
+    pub const DECREASE_LIQUIDITY_V2: [u8; 8] = [58, 127, 188, 62, 79, 82, 196, 96];
+    pub const INCREASE_LIQUIDITY_V2: [u8; 8] = [133, 29, 89, 223, 69, 238, 176, 10];
+
+    pub const TWO_HOP_SWAP_V2: [u8; 8] = [186, 143, 209, 29, 254, 2, 194, 117];
+    pub const SWAP_V2: [u8; 8] = [43, 4, 237, 11, 26, 201, 30, 98];
 }
 
+pub const ZERO_STRING: &str = "0";
 pub const ORCA_WHIRLPOOL: [u8; 32] = b58!("whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc");

--- a/orca-whirlpool/src/instructions/decrease_liquidity.rs
+++ b/orca-whirlpool/src/instructions/decrease_liquidity.rs
@@ -1,8 +1,13 @@
+use crate::pb::messari::orca_whirlpool::v1::event::Type;
+use crate::pb::messari::orca_whirlpool::v1::{decrease_liquidity, DecreaseLiquidity};
 use crate::traits::account_deserialize::AccountsDeserialize;
+use crate::traits::balance_of::BalanceOf;
+use crate::utils;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use derive_deserialize::AccountsDeserialize;
 use substreams_solana::block_view::InstructionView;
+use substreams_solana::pb::sf::solana::r#type::v1::ConfirmedTransaction;
 use substreams_solana::Address;
 
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
@@ -28,4 +33,45 @@ pub struct DecreaseLiquidityInstructionAccounts<'a> {
     pub token_vault_b: Address<'a>,
     pub tick_array_lower: Address<'a>,
     pub tick_array_upper: Address<'a>,
+}
+
+pub fn process_decrease_liquidity(
+    data: DecreaseLiquidityInstruction,
+    input_accounts: DecreaseLiquidityInstructionAccounts,
+    confirmed_txn: &ConfirmedTransaction,
+) -> Option<Type> {
+    let (token_a_pre_bal, token_a_post_bal) =
+        confirmed_txn.balance_of(&input_accounts.whirlpool, &input_accounts.token_vault_a);
+    let (token_b_pre_bal, token_b_post_bal) =
+        confirmed_txn.balance_of(&input_accounts.whirlpool, &input_accounts.token_vault_b);
+
+    Some(Type::DecreaseLiquidity(DecreaseLiquidity {
+        instruction: Some(decrease_liquidity::Instruction {
+            liquidity_amount: data.liquidity_amount.to_string(),
+
+            token_min_a: data.token_min_a.to_string(),
+            token_min_b: data.token_min_b.to_string(),
+
+            amount_a: utils::balance_difference(token_a_pre_bal.clone(), token_a_post_bal.clone()),
+            amount_a_pre: token_a_pre_bal.clone(),
+            amount_a_post: token_a_post_bal.clone(),
+
+            amount_b: utils::balance_difference(token_b_pre_bal.clone(), token_b_post_bal.clone()),
+            amount_b_pre: token_b_pre_bal.clone(),
+            amount_b_post: token_b_post_bal.clone(),
+        }),
+        accounts: Some(decrease_liquidity::Accounts {
+            whirlpool: input_accounts.whirlpool.to_string(),
+            token_program: input_accounts.token_program.to_string(),
+            position_authority: input_accounts.position_authority.to_string(),
+            position: input_accounts.position.to_string(),
+            position_token_account: input_accounts.position_token_account.to_string(),
+            token_owner_account_a: input_accounts.token_owner_account_a.to_string(),
+            token_owner_account_b: input_accounts.token_owner_account_b.to_string(),
+            token_vault_a: input_accounts.token_vault_a.to_string(),
+            token_vault_b: input_accounts.token_vault_b.to_string(),
+            tick_array_lower: input_accounts.tick_array_lower.to_string(),
+            tick_array_upper: input_accounts.tick_array_upper.to_string(),
+        }),
+    }))
 }

--- a/orca-whirlpool/src/instructions/decrease_liquidity_v2.rs
+++ b/orca-whirlpool/src/instructions/decrease_liquidity_v2.rs
@@ -1,5 +1,5 @@
 use crate::pb::messari::orca_whirlpool::v1::event::Type;
-use crate::pb::messari::orca_whirlpool::v1::{increase_liquidity, IncreaseLiquidity};
+use crate::pb::messari::orca_whirlpool::v1::{decrease_liquidity_v2, DecreaseLiquidityV2};
 use crate::traits::account_deserialize::AccountsDeserialize;
 use crate::traits::balance_of::BalanceOf;
 use crate::utils;
@@ -10,23 +10,31 @@ use substreams_solana::block_view::InstructionView;
 use substreams_solana::pb::sf::solana::r#type::v1::ConfirmedTransaction;
 use substreams_solana::Address;
 
-#[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
-pub struct IncreaseLiquidityInstruction {
-    // The total amount of Liquidity the user is willing to deposit.
+use super::utils::RemainingAccountsInfo;
+
+#[derive(BorshSerialize, BorshDeserialize, Debug)]
+pub struct DecreaseLiquidityInstructionV2 {
+    // The total amount of Liquidity the user desires to withdraw.
     pub liquidity_amount: u128,
-    // The maximum amount of tokenA the user is willing to deposit.
-    pub token_max_a: u64,
-    // The maximum amount of tokenB the user is willing to deposit.
-    pub token_max_b: u64,
+    // The minimum amount of tokenA the user is willing to withdraw.
+    pub token_min_a: u64,
+    // The minimum amount of tokenB the user is willing to withdraw.
+    pub token_min_b: u64,
+    // Remaining accounts info
+    pub remaining_accounts_info: Option<RemainingAccountsInfo>,
 }
 
 #[derive(AccountsDeserialize, Debug)]
-pub struct IncreaseLiquidityInstructionAccounts<'a> {
+pub struct DecreaseLiquidityInstructionAccountsV2<'a> {
     pub whirlpool: Address<'a>,
-    pub token_program: Address<'a>,
+    pub token_program_a: Address<'a>,
+    pub token_program_b: Address<'a>,
+    pub memo_program: Address<'a>,
     pub position_authority: Address<'a>,
     pub position: Address<'a>,
     pub position_token_account: Address<'a>,
+    pub token_mint_a: Address<'a>,
+    pub token_mint_b: Address<'a>,
     pub token_owner_account_a: Address<'a>,
     pub token_owner_account_b: Address<'a>,
     pub token_vault_a: Address<'a>,
@@ -35,9 +43,9 @@ pub struct IncreaseLiquidityInstructionAccounts<'a> {
     pub tick_array_upper: Address<'a>,
 }
 
-pub fn process_increase_liquidity(
-    data: IncreaseLiquidityInstruction,
-    input_accounts: IncreaseLiquidityInstructionAccounts,
+pub fn process_decrease_liquidity_v2(
+    data: DecreaseLiquidityInstructionV2,
+    input_accounts: DecreaseLiquidityInstructionAccountsV2,
     confirmed_txn: &ConfirmedTransaction,
 ) -> Option<Type> {
     let (token_a_pre_bal, token_a_post_bal) =
@@ -45,12 +53,12 @@ pub fn process_increase_liquidity(
     let (token_b_pre_bal, token_b_post_bal) =
         confirmed_txn.balance_of(&input_accounts.whirlpool, &input_accounts.token_vault_b);
 
-    Some(Type::IncreaseLiquidity(IncreaseLiquidity {
-        instruction: Some(increase_liquidity::Instruction {
+    Some(Type::DecreaseLiquidityV2(DecreaseLiquidityV2 {
+        instruction: Some(decrease_liquidity_v2::Instruction {
             liquidity_amount: data.liquidity_amount.to_string(),
 
-            token_max_a: data.token_max_a.to_string(),
-            token_max_b: data.token_max_b.to_string(),
+            token_min_a: data.token_min_a.to_string(),
+            token_min_b: data.token_min_b.to_string(),
 
             amount_a: utils::balance_difference(token_a_pre_bal.clone(), token_a_post_bal.clone()),
             amount_a_pre: token_a_pre_bal.clone(),
@@ -60,12 +68,16 @@ pub fn process_increase_liquidity(
             amount_b_pre: token_b_pre_bal.clone(),
             amount_b_post: token_b_post_bal.clone(),
         }),
-        accounts: Some(increase_liquidity::Accounts {
+        accounts: Some(decrease_liquidity_v2::Accounts {
             whirlpool: input_accounts.whirlpool.to_string(),
-            token_program: input_accounts.token_program.to_string(),
+            token_program_a: input_accounts.token_program_a.to_string(),
+            token_program_b: input_accounts.token_program_b.to_string(),
+            memo_program: input_accounts.memo_program.to_string(),
             position_authority: input_accounts.position_authority.to_string(),
             position: input_accounts.position.to_string(),
             position_token_account: input_accounts.position_token_account.to_string(),
+            token_mint_a: input_accounts.token_mint_a.to_string(),
+            token_mint_b: input_accounts.token_mint_b.to_string(),
             token_owner_account_a: input_accounts.token_owner_account_a.to_string(),
             token_owner_account_b: input_accounts.token_owner_account_b.to_string(),
             token_vault_a: input_accounts.token_vault_a.to_string(),

--- a/orca-whirlpool/src/instructions/increase_liquidity_v2.rs
+++ b/orca-whirlpool/src/instructions/increase_liquidity_v2.rs
@@ -1,5 +1,5 @@
 use crate::pb::messari::orca_whirlpool::v1::event::Type;
-use crate::pb::messari::orca_whirlpool::v1::{increase_liquidity, IncreaseLiquidity};
+use crate::pb::messari::orca_whirlpool::v1::{increase_liquidity_v2, IncreaseLiquidityV2};
 use crate::traits::account_deserialize::AccountsDeserialize;
 use crate::traits::balance_of::BalanceOf;
 use crate::utils;
@@ -10,23 +10,31 @@ use substreams_solana::block_view::InstructionView;
 use substreams_solana::pb::sf::solana::r#type::v1::ConfirmedTransaction;
 use substreams_solana::Address;
 
-#[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
-pub struct IncreaseLiquidityInstruction {
+use super::utils::RemainingAccountsInfo;
+
+#[derive(BorshSerialize, BorshDeserialize, Debug)]
+pub struct IncreaseLiquidityInstructionV2 {
     // The total amount of Liquidity the user is willing to deposit.
     pub liquidity_amount: u128,
     // The maximum amount of tokenA the user is willing to deposit.
     pub token_max_a: u64,
     // The maximum amount of tokenB the user is willing to deposit.
     pub token_max_b: u64,
+    // Remaining accounts info
+    pub remaining_accounts_info: Option<RemainingAccountsInfo>,
 }
 
 #[derive(AccountsDeserialize, Debug)]
-pub struct IncreaseLiquidityInstructionAccounts<'a> {
+pub struct IncreaseLiquidityInstructionAccountsV2<'a> {
     pub whirlpool: Address<'a>,
-    pub token_program: Address<'a>,
+    pub token_program_a: Address<'a>,
+    pub token_program_b: Address<'a>,
+    pub memo_program: Address<'a>,
     pub position_authority: Address<'a>,
     pub position: Address<'a>,
     pub position_token_account: Address<'a>,
+    pub token_mint_a: Address<'a>,
+    pub token_mint_b: Address<'a>,
     pub token_owner_account_a: Address<'a>,
     pub token_owner_account_b: Address<'a>,
     pub token_vault_a: Address<'a>,
@@ -35,9 +43,9 @@ pub struct IncreaseLiquidityInstructionAccounts<'a> {
     pub tick_array_upper: Address<'a>,
 }
 
-pub fn process_increase_liquidity(
-    data: IncreaseLiquidityInstruction,
-    input_accounts: IncreaseLiquidityInstructionAccounts,
+pub fn process_increase_liquidity_v2(
+    data: IncreaseLiquidityInstructionV2,
+    input_accounts: IncreaseLiquidityInstructionAccountsV2,
     confirmed_txn: &ConfirmedTransaction,
 ) -> Option<Type> {
     let (token_a_pre_bal, token_a_post_bal) =
@@ -45,8 +53,8 @@ pub fn process_increase_liquidity(
     let (token_b_pre_bal, token_b_post_bal) =
         confirmed_txn.balance_of(&input_accounts.whirlpool, &input_accounts.token_vault_b);
 
-    Some(Type::IncreaseLiquidity(IncreaseLiquidity {
-        instruction: Some(increase_liquidity::Instruction {
+    Some(Type::IncreaseLiquidityV2(IncreaseLiquidityV2 {
+        instruction: Some(increase_liquidity_v2::Instruction {
             liquidity_amount: data.liquidity_amount.to_string(),
 
             token_max_a: data.token_max_a.to_string(),
@@ -60,12 +68,16 @@ pub fn process_increase_liquidity(
             amount_b_pre: token_b_pre_bal.clone(),
             amount_b_post: token_b_post_bal.clone(),
         }),
-        accounts: Some(increase_liquidity::Accounts {
+        accounts: Some(increase_liquidity_v2::Accounts {
             whirlpool: input_accounts.whirlpool.to_string(),
-            token_program: input_accounts.token_program.to_string(),
+            token_program_a: input_accounts.token_program_a.to_string(),
+            token_program_b: input_accounts.token_program_b.to_string(),
+            memo_program: input_accounts.memo_program.to_string(),
             position_authority: input_accounts.position_authority.to_string(),
             position: input_accounts.position.to_string(),
             position_token_account: input_accounts.position_token_account.to_string(),
+            token_mint_a: input_accounts.token_mint_a.to_string(),
+            token_mint_b: input_accounts.token_mint_b.to_string(),
             token_owner_account_a: input_accounts.token_owner_account_a.to_string(),
             token_owner_account_b: input_accounts.token_owner_account_b.to_string(),
             token_vault_a: input_accounts.token_vault_a.to_string(),

--- a/orca-whirlpool/src/instructions/initialize_pool.rs
+++ b/orca-whirlpool/src/instructions/initialize_pool.rs
@@ -1,3 +1,5 @@
+use crate::pb::messari::orca_whirlpool::v1::event::Type;
+use crate::pb::messari::orca_whirlpool::v1::{initialize_pool, InitializePool};
 use crate::traits::account_deserialize::AccountsDeserialize;
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -5,10 +7,7 @@ use derive_deserialize::AccountsDeserialize;
 use substreams_solana::block_view::InstructionView;
 use substreams_solana::Address;
 
-#[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
-pub struct WhirlpoolBumps {
-    pub whirlpool_bump: u8,
-}
+use super::utils::WhirlpoolBumps;
 
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
 pub struct InitializePoolInstruction {
@@ -33,4 +32,30 @@ pub struct InitializePoolInstructionAccounts<'a> {
     pub token_program: Address<'a>,
     pub system_program: Address<'a>,
     pub rent: Address<'a>,
+}
+
+pub fn process_initialize_pool(
+    data: InitializePoolInstruction,
+    input_accounts: InitializePoolInstructionAccounts,
+) -> Option<Type> {
+    Some(Type::InitializePool(InitializePool {
+        instruction: Some(initialize_pool::Instruction {
+            bumps: data.bumps.whirlpool_bump as u32,
+            tick_spacing: data.tick_spacing as u32,
+            initial_sqrt_price: data.initial_sqrt_price.to_string(),
+        }),
+        accounts: Some(initialize_pool::Accounts {
+            whirlpools_config: input_accounts.whirlpools_config.to_string(),
+            token_mint_a: input_accounts.token_mint_a.to_string(),
+            token_mint_b: input_accounts.token_mint_b.to_string(),
+            funder: input_accounts.funder.to_string(),
+            whirlpool: input_accounts.whirlpool.to_string(),
+            token_vault_a: input_accounts.token_vault_a.to_string(),
+            token_vault_b: input_accounts.token_vault_b.to_string(),
+            fee_tier: input_accounts.fee_tier.to_string(),
+            token_program: input_accounts.token_program.to_string(),
+            system_program: input_accounts.system_program.to_string(),
+            rent: input_accounts.rent.to_string(),
+        }),
+    }))
 }

--- a/orca-whirlpool/src/instructions/initialize_pool_v2.rs
+++ b/orca-whirlpool/src/instructions/initialize_pool_v2.rs
@@ -1,3 +1,5 @@
+use crate::pb::messari::orca_whirlpool::v1::event::Type;
+use crate::pb::messari::orca_whirlpool::v1::{initialize_pool_v2, InitializePoolV2};
 use crate::traits::account_deserialize::AccountsDeserialize;
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -34,4 +36,30 @@ pub struct InitializePoolInstructionAccountsV2<'a> {
     pub token_program_b: Address<'a>,
     pub system_program: Address<'a>,
     pub rent: Address<'a>,
+}
+
+pub fn process_initialize_pool_v2(
+    data: InitializePoolInstructionV2,
+    input_accounts: InitializePoolInstructionAccountsV2,
+) -> Option<Type> {
+    Some(Type::InitializePoolV2(InitializePoolV2 {
+        instruction: Some(initialize_pool_v2::Instruction {
+            tick_spacing: data.tick_spacing as u32,
+            initial_sqrt_price: data.initial_sqrt_price.to_string(),
+        }),
+        accounts: Some(initialize_pool_v2::Accounts {
+            whirlpools_config: input_accounts.whirlpools_config.to_string(),
+            token_mint_a: input_accounts.token_mint_a.to_string(),
+            token_mint_b: input_accounts.token_mint_b.to_string(),
+            funder: input_accounts.funder.to_string(),
+            whirlpool: input_accounts.whirlpool.to_string(),
+            token_vault_a: input_accounts.token_vault_a.to_string(),
+            token_vault_b: input_accounts.token_vault_b.to_string(),
+            fee_tier: input_accounts.fee_tier.to_string(),
+            token_program_a: input_accounts.token_program_a.to_string(),
+            token_program_b: input_accounts.token_program_b.to_string(),
+            system_program: input_accounts.system_program.to_string(),
+            rent: input_accounts.rent.to_string(),
+        }),
+    }))
 }

--- a/orca-whirlpool/src/instructions/mod.rs
+++ b/orca-whirlpool/src/instructions/mod.rs
@@ -1,6 +1,11 @@
 pub mod decrease_liquidity;
+pub mod decrease_liquidity_v2;
 pub mod increase_liquidity;
+pub mod increase_liquidity_v2;
 pub mod initialize_pool;
 pub mod initialize_pool_v2;
 pub mod swap;
+pub mod swap_v2;
 pub mod two_hop_swap;
+pub mod two_hop_swap_v2;
+pub mod utils;

--- a/orca-whirlpool/src/instructions/utils.rs
+++ b/orca-whirlpool/src/instructions/utils.rs
@@ -1,0 +1,30 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug)]
+pub enum AccountsType {
+    TransferHookA,
+    TransferHookB,
+    TransferHookReward,
+    TransferHookInput,
+    TransferHookIntermediate,
+    TransferHookOutput,
+    SupplementalTickArrays,
+    SupplementalTickArraysOne,
+    SupplementalTickArraysTwo,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
+pub struct WhirlpoolBumps {
+    pub whirlpool_bump: u8,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug)]
+pub struct RemainingAccountsSlice {
+    pub accounts_type: AccountsType,
+    pub length: u8,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Clone, Debug)]
+pub struct RemainingAccountsInfo {
+    pub slices: Vec<RemainingAccountsSlice>,
+}

--- a/orca-whirlpool/src/modules/1_map_block.rs
+++ b/orca-whirlpool/src/modules/1_map_block.rs
@@ -1,28 +1,17 @@
 use crate::constants;
+use crate::instructions::{
+    decrease_liquidity::process_decrease_liquidity,
+    decrease_liquidity_v2::process_decrease_liquidity_v2,
+    increase_liquidity::process_increase_liquidity,
+    increase_liquidity_v2::process_increase_liquidity_v2, initialize_pool::process_initialize_pool,
+    initialize_pool_v2::process_initialize_pool_v2, swap::process_swap, swap_v2::process_swap_v2,
+    two_hop_swap::process_two_hop_swap, two_hop_swap_v2::process_two_hop_swap_v2,
+};
 use crate::orca_instructions::OrcaInstructions;
-use crate::traits::balance_of::BalanceOf;
-use crate::utils;
-use crate::{
-    instructions::{
-        decrease_liquidity::{DecreaseLiquidityInstruction, DecreaseLiquidityInstructionAccounts},
-        increase_liquidity::{IncreaseLiquidityInstruction, IncreaseLiquidityInstructionAccounts},
-        initialize_pool::{InitializePoolInstruction, InitializePoolInstructionAccounts},
-        initialize_pool_v2::{InitializePoolInstructionAccountsV2, InitializePoolInstructionV2},
-        swap::{SwapInstruction, SwapInstructionAccounts},
-        two_hop_swap::{TwoHopSwapInstruction, TwoHopSwapInstructionAccounts},
-    },
-    pb::messari::orca_whirlpool::v1::{
-        decrease_liquidity, event::Type, increase_liquidity, initialize_pool, initialize_pool_v2,
-        orca_swap, two_hop_swap, DecreaseLiquidity, Event, Events, IncreaseLiquidity,
-        InitializePool, InitializePoolV2, OrcaSwap, TwoHopSwap,
-    },
-};
+use crate::pb::messari::orca_whirlpool::v1::{Event, Events};
+
 use substreams::skip_empty_output;
-use substreams_solana::{
-    block_view::InstructionView,
-    pb::sf::solana::r#type::v1::{Block, ConfirmedTransaction},
-    Address,
-};
+use substreams_solana::pb::sf::solana::r#type::v1::{Block, ConfirmedTransaction};
 
 #[substreams::handlers::map]
 fn map_block(block: Block) -> Result<Events, substreams::errors::Error> {
@@ -37,22 +26,18 @@ fn map_block(block: Block) -> Result<Events, substreams::errors::Error> {
 }
 
 fn process_txn(confirmed_txn: &ConfirmedTransaction, block: &Block) -> Vec<Event> {
-    let all_instructions = confirmed_txn.walk_instructions().collect::<Vec<_>>();
-
-    all_instructions
-        .iter()
+    confirmed_txn
+        .walk_instructions()
         .filter(|instr| instr.program_id() == constants::ORCA_WHIRLPOOL)
         .filter_map(|instr| {
-            OrcaInstructions::from(instr).and_then(|decoded_instr| {
-                process_instruction(decoded_instr, &all_instructions, confirmed_txn, block)
-            })
+            OrcaInstructions::from(&instr)
+                .and_then(|decoded_instr| process_instruction(decoded_instr, confirmed_txn, block))
         })
         .collect()
 }
 
 fn process_instruction(
     decoded_instr: OrcaInstructions,
-    all_instructions: &[InstructionView],
     confirmed_txn: &ConfirmedTransaction,
     block: &Block,
 ) -> Option<Event> {
@@ -66,14 +51,26 @@ fn process_instruction(
         OrcaInstructions::IncreaseLiquidity(data, input_accounts) => {
             process_increase_liquidity(data, input_accounts, confirmed_txn)
         }
+        OrcaInstructions::IncreaseLiquidityV2(data, input_accounts) => {
+            process_increase_liquidity_v2(data, input_accounts, confirmed_txn)
+        }
         OrcaInstructions::DecreaseLiquidity(data, input_accounts) => {
             process_decrease_liquidity(data, input_accounts, confirmed_txn)
         }
+        OrcaInstructions::DecreaseLiquidityV2(data, input_accounts) => {
+            process_decrease_liquidity_v2(data, input_accounts, confirmed_txn)
+        }
         OrcaInstructions::TwoHopSwap(data, input_accounts) => {
-            process_two_hop_swap(data, input_accounts, all_instructions, confirmed_txn)
+            process_two_hop_swap(data, input_accounts, confirmed_txn)
+        }
+        OrcaInstructions::TwoHopSwapV2(data, input_accounts) => {
+            process_two_hop_swap_v2(data, input_accounts, confirmed_txn)
         }
         OrcaInstructions::Swap(data, input_accounts) => {
             process_swap(data, input_accounts, confirmed_txn)
+        }
+        OrcaInstructions::SwapV2(data, input_accounts) => {
+            process_swap_v2(data, input_accounts, confirmed_txn)
         }
     };
 
@@ -85,325 +82,4 @@ fn process_instruction(
         block_hash: block.blockhash.clone(),
         r#type: Some(r#type),
     })
-}
-
-fn process_initialize_pool(
-    data: InitializePoolInstruction,
-    input_accounts: InitializePoolInstructionAccounts,
-) -> Option<Type> {
-    Some(Type::InitializePool(InitializePool {
-        instruction: Some(initialize_pool::Instruction {
-            bumps: data.bumps.whirlpool_bump as u32,
-            tick_spacing: data.tick_spacing as u32,
-            initial_sqrt_price: data.initial_sqrt_price.to_string(),
-        }),
-        accounts: Some(initialize_pool::Accounts {
-            whirlpools_config: input_accounts.whirlpools_config.to_string(),
-            token_mint_a: input_accounts.token_mint_a.to_string(),
-            token_mint_b: input_accounts.token_mint_b.to_string(),
-            funder: input_accounts.funder.to_string(),
-            whirlpool: input_accounts.whirlpool.to_string(),
-            token_vault_a: input_accounts.token_vault_a.to_string(),
-            token_vault_b: input_accounts.token_vault_b.to_string(),
-            fee_tier: input_accounts.fee_tier.to_string(),
-            token_program: input_accounts.token_program.to_string(),
-            system_program: input_accounts.system_program.to_string(),
-            rent: input_accounts.rent.to_string(),
-        }),
-    }))
-}
-
-fn process_initialize_pool_v2(
-    data: InitializePoolInstructionV2,
-    input_accounts: InitializePoolInstructionAccountsV2,
-) -> Option<Type> {
-    Some(Type::InitializePoolV2(InitializePoolV2 {
-        instruction: Some(initialize_pool_v2::Instruction {
-            tick_spacing: data.tick_spacing as u32,
-            initial_sqrt_price: data.initial_sqrt_price.to_string(),
-        }),
-        accounts: Some(initialize_pool_v2::Accounts {
-            whirlpools_config: input_accounts.whirlpools_config.to_string(),
-            token_mint_a: input_accounts.token_mint_a.to_string(),
-            token_mint_b: input_accounts.token_mint_b.to_string(),
-            funder: input_accounts.funder.to_string(),
-            whirlpool: input_accounts.whirlpool.to_string(),
-            token_vault_a: input_accounts.token_vault_a.to_string(),
-            token_vault_b: input_accounts.token_vault_b.to_string(),
-            fee_tier: input_accounts.fee_tier.to_string(),
-            token_program_a: input_accounts.token_program_a.to_string(),
-            token_program_b: input_accounts.token_program_b.to_string(),
-            system_program: input_accounts.system_program.to_string(),
-            rent: input_accounts.rent.to_string(),
-        }),
-    }))
-}
-
-fn process_increase_liquidity(
-    data: IncreaseLiquidityInstruction,
-    input_accounts: IncreaseLiquidityInstructionAccounts,
-    confirmed_txn: &ConfirmedTransaction,
-) -> Option<Type> {
-    let (token_a_pre_bal, token_a_post_bal) =
-        confirmed_txn.balance_of(&input_accounts.whirlpool, &input_accounts.token_vault_a);
-    let (token_b_pre_bal, token_b_post_bal) =
-        confirmed_txn.balance_of(&input_accounts.whirlpool, &input_accounts.token_vault_b);
-
-    Some(Type::IncreaseLiquidity(IncreaseLiquidity {
-        instruction: Some(increase_liquidity::Instruction {
-            liquidity_amount: data.liquidity_amount.to_string(),
-
-            token_max_a: data.token_max_a.to_string(),
-            token_max_b: data.token_max_b.to_string(),
-
-            amount_a: utils::balance_difference(token_a_pre_bal.clone(), token_a_post_bal.clone()),
-            amount_a_pre: token_a_pre_bal.clone(),
-            amount_a_post: token_a_post_bal.clone(),
-
-            amount_b: utils::balance_difference(token_b_pre_bal.clone(), token_b_post_bal.clone()),
-            amount_b_pre: token_b_pre_bal.clone(),
-            amount_b_post: token_b_post_bal.clone(),
-        }),
-        accounts: Some(increase_liquidity::Accounts {
-            whirlpool: input_accounts.whirlpool.to_string(),
-            token_program: input_accounts.token_program.to_string(),
-            position_authority: input_accounts.position_authority.to_string(),
-            position: input_accounts.position.to_string(),
-            position_token_account: input_accounts.position_token_account.to_string(),
-            token_owner_account_a: input_accounts.token_owner_account_a.to_string(),
-            token_owner_account_b: input_accounts.token_owner_account_b.to_string(),
-            token_vault_a: input_accounts.token_vault_a.to_string(),
-            token_vault_b: input_accounts.token_vault_b.to_string(),
-            tick_array_lower: input_accounts.tick_array_lower.to_string(),
-            tick_array_upper: input_accounts.tick_array_upper.to_string(),
-        }),
-    }))
-}
-
-fn process_decrease_liquidity(
-    data: DecreaseLiquidityInstruction,
-    input_accounts: DecreaseLiquidityInstructionAccounts,
-    confirmed_txn: &ConfirmedTransaction,
-) -> Option<Type> {
-    let (token_a_pre_bal, token_a_post_bal) =
-        confirmed_txn.balance_of(&input_accounts.whirlpool, &input_accounts.token_vault_a);
-    let (token_b_pre_bal, token_b_post_bal) =
-        confirmed_txn.balance_of(&input_accounts.whirlpool, &input_accounts.token_vault_b);
-
-    Some(Type::DecreaseLiquidity(DecreaseLiquidity {
-        instruction: Some(decrease_liquidity::Instruction {
-            liquidity_amount: data.liquidity_amount.to_string(),
-
-            token_min_a: data.token_min_a.to_string(),
-            token_min_b: data.token_min_b.to_string(),
-
-            amount_a: utils::balance_difference(token_a_pre_bal.clone(), token_a_post_bal.clone()),
-            amount_a_pre: token_a_pre_bal.clone(),
-            amount_a_post: token_a_post_bal.clone(),
-
-            amount_b: utils::balance_difference(token_b_pre_bal.clone(), token_b_post_bal.clone()),
-            amount_b_pre: token_b_pre_bal.clone(),
-            amount_b_post: token_b_post_bal.clone(),
-        }),
-        accounts: Some(decrease_liquidity::Accounts {
-            whirlpool: input_accounts.whirlpool.to_string(),
-            token_program: input_accounts.token_program.to_string(),
-            position_authority: input_accounts.position_authority.to_string(),
-            position: input_accounts.position.to_string(),
-            position_token_account: input_accounts.position_token_account.to_string(),
-            token_owner_account_a: input_accounts.token_owner_account_a.to_string(),
-            token_owner_account_b: input_accounts.token_owner_account_b.to_string(),
-            token_vault_a: input_accounts.token_vault_a.to_string(),
-            token_vault_b: input_accounts.token_vault_b.to_string(),
-            tick_array_lower: input_accounts.tick_array_lower.to_string(),
-            tick_array_upper: input_accounts.tick_array_upper.to_string(),
-        }),
-    }))
-}
-
-fn process_two_hop_swap(
-    data: TwoHopSwapInstruction,
-    input_accounts: TwoHopSwapInstructionAccounts,
-    all_instructions: &[InstructionView],
-    confirmed_txn: &ConfirmedTransaction,
-) -> Option<Type> {
-    let transfer_a_one_instr_addresses = get_transfer_addresses(
-        data.a_to_b_one,
-        &input_accounts.token_owner_account_one_a,
-        &input_accounts.token_vault_one_a,
-        &input_accounts.token_authority,
-        &input_accounts.whirlpool_one,
-    );
-    let transfer_b_one_instr_addresses = get_transfer_addresses(
-        !data.a_to_b_one,
-        &input_accounts.token_owner_account_one_b,
-        &input_accounts.token_vault_one_b,
-        &input_accounts.token_authority,
-        &input_accounts.whirlpool_one,
-    );
-    let transfer_a_two_instr_addresses = get_transfer_addresses(
-        data.a_to_b_two,
-        &input_accounts.token_owner_account_two_a,
-        &input_accounts.token_vault_two_a,
-        &input_accounts.token_authority,
-        &input_accounts.whirlpool_two,
-    );
-    let transfer_b_two_instr_addresses = get_transfer_addresses(
-        !data.a_to_b_two,
-        &input_accounts.token_owner_account_two_b,
-        &input_accounts.token_vault_two_b,
-        &input_accounts.token_authority,
-        &input_accounts.whirlpool_two,
-    );
-
-    let transfer_token_a_one_instruction =
-        find_transfer_instruction(all_instructions, &transfer_a_one_instr_addresses);
-    let transfer_token_b_one_instruction =
-        find_transfer_instruction(all_instructions, &transfer_b_one_instr_addresses);
-    let transfer_token_a_two_instruction =
-        find_transfer_instruction(all_instructions, &transfer_a_two_instr_addresses);
-    let transfer_token_b_two_instruction =
-        find_transfer_instruction(all_instructions, &transfer_b_two_instr_addresses);
-
-    let (token_a_one_pre_bal, token_a_one_post_bal) = confirmed_txn.balance_of(
-        &input_accounts.whirlpool_one,
-        &input_accounts.token_vault_one_a,
-    );
-    let (token_b_one_pre_bal, token_b_one_post_bal) = confirmed_txn.balance_of(
-        &input_accounts.whirlpool_one,
-        &input_accounts.token_vault_one_b,
-    );
-    let (token_a_two_pre_bal, token_a_two_post_bal) = confirmed_txn.balance_of(
-        &input_accounts.whirlpool_two,
-        &input_accounts.token_vault_two_a,
-    );
-    let (token_b_two_pre_bal, token_b_two_post_bal) = confirmed_txn.balance_of(
-        &input_accounts.whirlpool_two,
-        &input_accounts.token_vault_two_b,
-    );
-
-    Some(Type::TwoHopSwap(TwoHopSwap {
-        instruction: Some(two_hop_swap::Instruction {
-            amount: data.amount.to_string(),
-
-            amount_a_one: utils::get_transfer_amount(transfer_token_a_one_instruction),
-            amount_b_one: utils::get_transfer_amount(transfer_token_b_one_instruction),
-
-            amount_a_one_pre: token_a_one_pre_bal.clone(),
-            amount_a_one_post: token_a_one_post_bal.clone(),
-
-            amount_b_one_pre: token_b_one_pre_bal.clone(),
-            amount_b_one_post: token_b_one_post_bal.clone(),
-
-            amount_a_two: utils::get_transfer_amount(transfer_token_a_two_instruction),
-            amount_b_two: utils::get_transfer_amount(transfer_token_b_two_instruction),
-
-            amount_a_two_pre: token_a_two_pre_bal.clone(),
-            amount_a_two_post: token_a_two_post_bal.clone(),
-
-            amount_b_two_pre: token_b_two_pre_bal.clone(),
-            amount_b_two_post: token_b_two_post_bal.clone(),
-
-            other_amount_threshold: data.other_amount_threshold.to_string(),
-
-            amount_specified_is_input: data.amount_specified_is_input,
-            a_to_b_one: data.a_to_b_one,
-            a_to_b_two: data.a_to_b_two,
-
-            sqrt_price_limit_one: data.sqrt_price_limit_one.to_string(),
-            sqrt_price_limit_two: data.sqrt_price_limit_two.to_string(),
-        }),
-        accounts: Some(two_hop_swap::Accounts {
-            token_program: input_accounts.token_program.to_string(),
-            token_authority: input_accounts.token_authority.to_string(),
-            whirlpool_one: input_accounts.whirlpool_one.to_string(),
-            whirlpool_two: input_accounts.whirlpool_two.to_string(),
-            token_owner_account_one_a: input_accounts.token_owner_account_one_a.to_string(),
-            token_vault_one_a: input_accounts.token_vault_one_a.to_string(),
-            token_owner_account_one_b: input_accounts.token_owner_account_one_b.to_string(),
-            token_vault_one_b: input_accounts.token_vault_one_b.to_string(),
-            token_owner_account_two_a: input_accounts.token_owner_account_two_a.to_string(),
-            token_vault_two_a: input_accounts.token_vault_two_a.to_string(),
-            token_owner_account_two_b: input_accounts.token_owner_account_two_b.to_string(),
-            token_vault_two_b: input_accounts.token_vault_two_b.to_string(),
-            tick_array_one0: input_accounts.tick_array_one0.to_string(),
-            tick_array_one1: input_accounts.tick_array_one1.to_string(),
-            tick_array_one2: input_accounts.tick_array_one2.to_string(),
-            tick_array_two0: input_accounts.tick_array_two0.to_string(),
-            tick_array_two1: input_accounts.tick_array_two1.to_string(),
-            tick_array_two2: input_accounts.tick_array_two2.to_string(),
-            oracle_one: input_accounts.oracle_one.to_string(),
-            oracle_two: input_accounts.oracle_two.to_string(),
-        }),
-    }))
-}
-
-fn process_swap(
-    data: SwapInstruction,
-    input_accounts: SwapInstructionAccounts,
-    confirmed_txn: &ConfirmedTransaction,
-) -> Option<Type> {
-    let (token_a_pre_bal, token_a_post_bal) =
-        confirmed_txn.balance_of(&input_accounts.whirlpool, &input_accounts.token_vault_a);
-    let (token_b_pre_bal, token_b_post_bal) =
-        confirmed_txn.balance_of(&input_accounts.whirlpool, &input_accounts.token_vault_b);
-
-    Some(Type::Swap(OrcaSwap {
-        instruction: Some(orca_swap::Instruction {
-            amount: data.amount.to_string(),
-
-            amount_a: utils::balance_difference(token_a_pre_bal.clone(), token_a_post_bal.clone()),
-            amount_a_pre: token_a_pre_bal.clone(),
-            amount_a_post: token_a_post_bal.clone(),
-
-            amount_b: utils::balance_difference(token_b_pre_bal.clone(), token_b_post_bal.clone()),
-            amount_b_pre: token_b_pre_bal.clone(),
-            amount_b_post: token_b_post_bal.clone(),
-
-            other_amount_threshold: data.other_amount_threshold.to_string(),
-            sqrt_price_limit: data.sqrt_price_limit.to_string(),
-
-            amount_specified_is_input: data.amount_specified_is_input,
-            a_to_b: data.a_to_b,
-        }),
-        accounts: Some(orca_swap::Accounts {
-            token_program: input_accounts.token_program.to_string(),
-            token_authority: input_accounts.token_authority.to_string(),
-            whirlpool: input_accounts.whirlpool.to_string(),
-            token_owner_account_a: input_accounts.token_owner_account_a.to_string(),
-            token_vault_a: input_accounts.token_vault_a.to_string(),
-            token_owner_account_b: input_accounts.token_owner_account_b.to_string(),
-            token_vault_b: input_accounts.token_vault_b.to_string(),
-            tick_array_0: input_accounts.tick_array_0.to_string(),
-            tick_array_1: input_accounts.tick_array_1.to_string(),
-            tick_array_2: input_accounts.tick_array_2.to_string(),
-            oracle: input_accounts.oracle.to_string(),
-        }),
-    }))
-}
-
-fn find_transfer_instruction<'a>(
-    all_instructions: &'a [InstructionView],
-    accounts: &[&'a Address<'a>],
-) -> Option<&'a InstructionView<'a>> {
-    all_instructions.iter().find(|iv| {
-        iv.accounts()
-            .iter()
-            .map(|acc| acc.to_string())
-            .eq(accounts.iter().map(|s| s.to_string()))
-    })
-}
-
-fn get_transfer_addresses<'a>(
-    is_a_to_b: bool,
-    owner_account: &'a Address<'a>,
-    vault_account: &'a Address<'a>,
-    authority: &'a Address<'a>,
-    whirlpool: &'a Address<'a>,
-) -> Vec<&'a Address<'a>> {
-    if is_a_to_b {
-        vec![owner_account, vault_account, authority]
-    } else {
-        vec![vault_account, owner_account, whirlpool]
-    }
 }

--- a/orca-whirlpool/src/modules/20_store_unique_users.rs
+++ b/orca-whirlpool/src/modules/20_store_unique_users.rs
@@ -28,10 +28,21 @@ pub fn store_unique_users(clock: Clock, raw_events: Events, store: StoreSetIfNot
 
 fn get_user_address(event: Type) -> Option<String> {
     match event {
+        // increase liquidity
         Type::IncreaseLiquidity(e) => Some(e.accounts.as_ref()?.position_authority.clone()),
+        Type::IncreaseLiquidityV2(e) => Some(e.accounts.as_ref()?.position_authority.clone()),
+
+        // decrease liquidity
         Type::DecreaseLiquidity(e) => Some(e.accounts.as_ref()?.position_authority.clone()),
+        Type::DecreaseLiquidityV2(e) => Some(e.accounts.as_ref()?.position_authority.clone()),
+
+        // two hop swap
         Type::TwoHopSwap(e) => Some(e.accounts.as_ref()?.token_authority.clone()),
+        Type::TwoHopSwapV2(e) => Some(e.accounts.as_ref()?.token_authority.clone()),
+
+        // swap
         Type::Swap(e) => Some(e.accounts.as_ref()?.token_authority.clone()),
+        Type::SwapV2(e) => Some(e.accounts.as_ref()?.token_authority.clone()),
         _ => None,
     }
 }

--- a/orca-whirlpool/src/modules/23_store_pool_balances.rs
+++ b/orca-whirlpool/src/modules/23_store_pool_balances.rs
@@ -60,6 +60,22 @@ pub fn store_pool_balances(
     });
 }
 
+/// Processes pool balances for a given set of items.
+///
+/// This function takes a collection of items, a store to update, and a closure that extracts
+/// balance information from each item. It then updates the store with the extracted balance
+/// information for each pool and token combination.
+///
+/// # Arguments
+///
+/// * `items` - A slice of items to process
+/// * `store` - The store to update with balance information
+/// * `f` - A closure that takes an item and returns a vector of (pool, token, balance) tuples
+///
+/// # Type Parameters
+///
+/// * `T` - The type of items being processed
+/// * `F` - The type of the closure for extracting balance information
 fn process_pool_balances<T, F>(items: &[T], store: &StoreSetBigInt, f: F)
 where
     F: Fn(&T) -> Vec<(String, String, String)>,

--- a/orca-whirlpool/src/orca_instructions.rs
+++ b/orca-whirlpool/src/orca_instructions.rs
@@ -1,11 +1,19 @@
 use crate::constants;
 use crate::instructions::{
     decrease_liquidity::{DecreaseLiquidityInstruction, DecreaseLiquidityInstructionAccounts},
+    decrease_liquidity_v2::{
+        DecreaseLiquidityInstructionAccountsV2, DecreaseLiquidityInstructionV2,
+    },
     increase_liquidity::{IncreaseLiquidityInstruction, IncreaseLiquidityInstructionAccounts},
+    increase_liquidity_v2::{
+        IncreaseLiquidityInstructionAccountsV2, IncreaseLiquidityInstructionV2,
+    },
     initialize_pool::{InitializePoolInstruction, InitializePoolInstructionAccounts},
     initialize_pool_v2::{InitializePoolInstructionAccountsV2, InitializePoolInstructionV2},
     swap::{SwapInstruction, SwapInstructionAccounts},
+    swap_v2::{SwapInstructionAccountsV2, SwapInstructionV2},
     two_hop_swap::{TwoHopSwapInstruction, TwoHopSwapInstructionAccounts},
+    two_hop_swap_v2::{TwoHopSwapInstructionAccountsV2, TwoHopSwapInstructionV2},
 };
 
 use crate::traits::account_deserialize::AccountsDeserialize;
@@ -27,12 +35,22 @@ pub enum OrcaInstructions<'a> {
         IncreaseLiquidityInstruction,
         IncreaseLiquidityInstructionAccounts<'a>,
     ),
+    IncreaseLiquidityV2(
+        IncreaseLiquidityInstructionV2,
+        IncreaseLiquidityInstructionAccountsV2<'a>,
+    ),
     DecreaseLiquidity(
         DecreaseLiquidityInstruction,
         DecreaseLiquidityInstructionAccounts<'a>,
     ),
+    DecreaseLiquidityV2(
+        DecreaseLiquidityInstructionV2,
+        DecreaseLiquidityInstructionAccountsV2<'a>,
+    ),
     TwoHopSwap(TwoHopSwapInstruction, TwoHopSwapInstructionAccounts<'a>),
+    TwoHopSwapV2(TwoHopSwapInstructionV2, TwoHopSwapInstructionAccountsV2<'a>),
     Swap(SwapInstruction, SwapInstructionAccounts<'a>),
+    SwapV2(SwapInstructionV2, SwapInstructionAccountsV2<'a>),
 }
 
 impl<'a> OrcaInstructions<'a> {
@@ -70,12 +88,26 @@ impl<'a> OrcaInstructions<'a> {
                 >(&mut rest, instruction_view)?;
                 Some(OrcaInstructions::IncreaseLiquidity(data, input_accounts))
             }
+            x if x == constants::DiscriminatorConstants::INCREASE_LIQUIDITY_V2 => {
+                let (data, input_accounts) = Self::deserialize_instruction::<
+                    IncreaseLiquidityInstructionV2,
+                    IncreaseLiquidityInstructionAccountsV2,
+                >(&mut rest, instruction_view)?;
+                Some(OrcaInstructions::IncreaseLiquidityV2(data, input_accounts))
+            }
             x if x == constants::DiscriminatorConstants::DECREASE_LIQUIDITY => {
                 let (data, input_accounts) = Self::deserialize_instruction::<
                     DecreaseLiquidityInstruction,
                     DecreaseLiquidityInstructionAccounts,
                 >(&mut rest, instruction_view)?;
                 Some(OrcaInstructions::DecreaseLiquidity(data, input_accounts))
+            }
+            x if x == constants::DiscriminatorConstants::DECREASE_LIQUIDITY_V2 => {
+                let (data, input_accounts) = Self::deserialize_instruction::<
+                    DecreaseLiquidityInstructionV2,
+                    DecreaseLiquidityInstructionAccountsV2,
+                >(&mut rest, instruction_view)?;
+                Some(OrcaInstructions::DecreaseLiquidityV2(data, input_accounts))
             }
             x if x == constants::DiscriminatorConstants::TWO_HOP_SWAP => {
                 let (data, input_accounts) = Self::deserialize_instruction::<
@@ -84,12 +116,26 @@ impl<'a> OrcaInstructions<'a> {
                 >(&mut rest, instruction_view)?;
                 Some(OrcaInstructions::TwoHopSwap(data, input_accounts))
             }
+            x if x == constants::DiscriminatorConstants::TWO_HOP_SWAP_V2 => {
+                let (data, input_accounts) = Self::deserialize_instruction::<
+                    TwoHopSwapInstructionV2,
+                    TwoHopSwapInstructionAccountsV2,
+                >(&mut rest, instruction_view)?;
+                Some(OrcaInstructions::TwoHopSwapV2(data, input_accounts))
+            }
             x if x == constants::DiscriminatorConstants::SWAP => {
                 let (data, input_accounts) = Self::deserialize_instruction::<
                     SwapInstruction,
                     SwapInstructionAccounts,
                 >(&mut rest, instruction_view)?;
                 Some(OrcaInstructions::Swap(data, input_accounts))
+            }
+            x if x == constants::DiscriminatorConstants::SWAP_V2 => {
+                let (data, input_accounts) = Self::deserialize_instruction::<
+                    SwapInstructionV2,
+                    SwapInstructionAccountsV2,
+                >(&mut rest, instruction_view)?;
+                Some(OrcaInstructions::SwapV2(data, input_accounts))
             }
             _ => None,
         }

--- a/orca-whirlpool/src/traits/deposit_instructions.rs
+++ b/orca-whirlpool/src/traits/deposit_instructions.rs
@@ -1,0 +1,116 @@
+use crate::{
+    constants::ZERO_STRING,
+    pb::messari::orca_whirlpool::v1::{IncreaseLiquidity, IncreaseLiquidityV2},
+};
+
+pub trait DepositInstruction {
+    fn whirlpool(&self) -> String;
+    fn position_authority(&self) -> String;
+    fn amount_a(&self) -> String;
+    fn amount_b(&self) -> String;
+    fn amount_a_post(&self) -> String;
+    fn amount_b_post(&self) -> String;
+    fn liquidity_amount(&self) -> String;
+}
+
+impl DepositInstruction for IncreaseLiquidity {
+    fn whirlpool(&self) -> String {
+        self.accounts
+            .as_ref()
+            .map(|a| a.whirlpool.clone())
+            .unwrap_or_default()
+    }
+
+    fn position_authority(&self) -> String {
+        self.accounts
+            .as_ref()
+            .map(|a| a.position_authority.clone())
+            .unwrap_or_default()
+    }
+
+    fn amount_a(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_a_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn liquidity_amount(&self) -> String {
+        self.instruction
+            .as_ref()
+            .map(|i| i.liquidity_amount.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+}
+
+impl DepositInstruction for IncreaseLiquidityV2 {
+    fn whirlpool(&self) -> String {
+        self.accounts
+            .as_ref()
+            .map(|a| a.whirlpool.clone())
+            .unwrap_or_default()
+    }
+
+    fn position_authority(&self) -> String {
+        self.accounts
+            .as_ref()
+            .map(|a| a.position_authority.clone())
+            .unwrap_or_default()
+    }
+
+    fn amount_a(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_a_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn liquidity_amount(&self) -> String {
+        self.instruction
+            .as_ref()
+            .map(|i| i.liquidity_amount.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+}

--- a/orca-whirlpool/src/traits/mod.rs
+++ b/orca-whirlpool/src/traits/mod.rs
@@ -1,2 +1,5 @@
 pub mod account_deserialize;
 pub mod balance_of;
+pub mod deposit_instructions;
+pub mod swap_instructions;
+pub mod withdraw_instructions;

--- a/orca-whirlpool/src/traits/swap_instructions.rs
+++ b/orca-whirlpool/src/traits/swap_instructions.rs
@@ -1,0 +1,362 @@
+use crate::{
+    constants::ZERO_STRING,
+    pb::messari::orca_whirlpool::v1::{OrcaSwap, OrcaSwapV2, TwoHopSwap, TwoHopSwapV2},
+};
+
+pub trait SwapInstruction {
+    fn a_to_b(&self) -> bool;
+    fn amount_a(&self) -> String;
+    fn amount_b(&self) -> String;
+    fn amount_a_post(&self) -> String;
+    fn amount_b_post(&self) -> String;
+    fn token_authority(&self) -> String;
+    fn whirlpool(&self) -> String;
+    fn is_two_hop(&self) -> bool;
+    fn second_hop(&self) -> Option<Box<dyn SwapInstruction>>;
+}
+
+impl SwapInstruction for TwoHopSwap {
+    fn a_to_b(&self) -> bool {
+        self.instruction.as_ref().map_or(false, |i| i.a_to_b_one)
+    }
+
+    fn amount_a(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a_one.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b_one.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_a_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a_one_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b_one_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn token_authority(&self) -> String {
+        self.accounts
+            .as_ref()
+            .map(|a| a.token_authority.clone())
+            .unwrap()
+    }
+
+    fn whirlpool(&self) -> String {
+        self.accounts
+            .as_ref()
+            .map(|a| a.whirlpool_one.clone())
+            .unwrap()
+    }
+
+    fn is_two_hop(&self) -> bool {
+        true
+    }
+
+    fn second_hop(&self) -> Option<Box<dyn SwapInstruction>> {
+        Some(Box::new(TwoHopSwapSecondHop(self.clone())))
+    }
+}
+
+struct TwoHopSwapSecondHop(TwoHopSwap);
+
+impl SwapInstruction for TwoHopSwapSecondHop {
+    fn a_to_b(&self) -> bool {
+        self.0.instruction.as_ref().map_or(false, |i| i.a_to_b_two)
+    }
+
+    fn amount_a(&self) -> String {
+        self.0
+            .instruction
+            .as_ref()
+            .and_then(|i| i.amount_a_two.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b(&self) -> String {
+        self.0
+            .instruction
+            .as_ref()
+            .and_then(|i| i.amount_b_two.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_a_post(&self) -> String {
+        self.0
+            .instruction
+            .as_ref()
+            .and_then(|i| i.amount_a_two_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b_post(&self) -> String {
+        self.0
+            .instruction
+            .as_ref()
+            .and_then(|i| i.amount_b_two_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn token_authority(&self) -> String {
+        self.0
+            .accounts
+            .as_ref()
+            .map(|a| a.token_authority.clone())
+            .unwrap()
+    }
+
+    fn whirlpool(&self) -> String {
+        self.0
+            .accounts
+            .as_ref()
+            .map(|a| a.whirlpool_two.clone())
+            .unwrap()
+    }
+
+    fn is_two_hop(&self) -> bool {
+        false
+    }
+
+    fn second_hop(&self) -> Option<Box<dyn SwapInstruction>> {
+        None
+    }
+}
+
+impl SwapInstruction for TwoHopSwapV2 {
+    fn a_to_b(&self) -> bool {
+        self.instruction.as_ref().map_or(false, |i| i.a_to_b_one)
+    }
+
+    fn amount_a(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a_one.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b_one.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_a_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a_one_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b_one_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn token_authority(&self) -> String {
+        self.accounts
+            .as_ref()
+            .map(|a| a.token_authority.clone())
+            .unwrap()
+    }
+
+    fn whirlpool(&self) -> String {
+        self.accounts
+            .as_ref()
+            .map(|a| a.whirlpool_one.clone())
+            .unwrap()
+    }
+
+    fn is_two_hop(&self) -> bool {
+        true
+    }
+
+    fn second_hop(&self) -> Option<Box<dyn SwapInstruction>> {
+        Some(Box::new(TwoHopSwapV2SecondHop(self.clone())))
+    }
+}
+
+struct TwoHopSwapV2SecondHop(TwoHopSwapV2);
+
+impl SwapInstruction for TwoHopSwapV2SecondHop {
+    fn a_to_b(&self) -> bool {
+        self.0.instruction.as_ref().map_or(false, |i| i.a_to_b_two)
+    }
+
+    fn amount_a(&self) -> String {
+        self.0
+            .instruction
+            .as_ref()
+            .and_then(|i| i.amount_a_two.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b(&self) -> String {
+        self.0
+            .instruction
+            .as_ref()
+            .and_then(|i| i.amount_b_two.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_a_post(&self) -> String {
+        self.0
+            .instruction
+            .as_ref()
+            .and_then(|i| i.amount_a_two_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b_post(&self) -> String {
+        self.0
+            .instruction
+            .as_ref()
+            .and_then(|i| i.amount_b_two_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn token_authority(&self) -> String {
+        self.0
+            .accounts
+            .as_ref()
+            .map(|a| a.token_authority.clone())
+            .unwrap()
+    }
+
+    fn whirlpool(&self) -> String {
+        self.0
+            .accounts
+            .as_ref()
+            .map(|a| a.whirlpool_two.clone())
+            .unwrap()
+    }
+
+    fn is_two_hop(&self) -> bool {
+        false
+    }
+
+    fn second_hop(&self) -> Option<Box<dyn SwapInstruction>> {
+        None
+    }
+}
+
+impl SwapInstruction for OrcaSwap {
+    fn a_to_b(&self) -> bool {
+        self.instruction.as_ref().map_or(false, |i| i.a_to_b)
+    }
+
+    fn amount_a(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_a_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn token_authority(&self) -> String {
+        self.accounts
+            .as_ref()
+            .map(|a| a.token_authority.clone())
+            .unwrap()
+    }
+
+    fn whirlpool(&self) -> String {
+        self.accounts.as_ref().map(|a| a.whirlpool.clone()).unwrap()
+    }
+
+    fn is_two_hop(&self) -> bool {
+        false
+    }
+
+    fn second_hop(&self) -> Option<Box<dyn SwapInstruction>> {
+        None
+    }
+}
+
+impl SwapInstruction for OrcaSwapV2 {
+    fn a_to_b(&self) -> bool {
+        self.instruction.as_ref().map_or(false, |i| i.a_to_b)
+    }
+
+    fn amount_a(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_a_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn token_authority(&self) -> String {
+        self.accounts
+            .as_ref()
+            .map(|a| a.token_authority.clone())
+            .unwrap()
+    }
+
+    fn whirlpool(&self) -> String {
+        self.accounts.as_ref().map(|a| a.whirlpool.clone()).unwrap()
+    }
+
+    fn is_two_hop(&self) -> bool {
+        false
+    }
+
+    fn second_hop(&self) -> Option<Box<dyn SwapInstruction>> {
+        None
+    }
+}

--- a/orca-whirlpool/src/traits/withdraw_instructions.rs
+++ b/orca-whirlpool/src/traits/withdraw_instructions.rs
@@ -1,0 +1,116 @@
+use crate::{
+    constants::ZERO_STRING,
+    pb::messari::orca_whirlpool::v1::{DecreaseLiquidity, DecreaseLiquidityV2},
+};
+
+pub trait WithdrawInstruction {
+    fn whirlpool(&self) -> String;
+    fn position_authority(&self) -> String;
+    fn amount_a(&self) -> String;
+    fn amount_b(&self) -> String;
+    fn amount_a_post(&self) -> String;
+    fn amount_b_post(&self) -> String;
+    fn liquidity_amount(&self) -> String;
+}
+
+impl WithdrawInstruction for DecreaseLiquidity {
+    fn whirlpool(&self) -> String {
+        self.accounts
+            .as_ref()
+            .map(|a| a.whirlpool.clone())
+            .unwrap_or_default()
+    }
+
+    fn position_authority(&self) -> String {
+        self.accounts
+            .as_ref()
+            .map(|a| a.position_authority.clone())
+            .unwrap_or_default()
+    }
+
+    fn amount_a(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_a_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn liquidity_amount(&self) -> String {
+        self.instruction
+            .as_ref()
+            .map(|i| i.liquidity_amount.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+}
+
+impl WithdrawInstruction for DecreaseLiquidityV2 {
+    fn whirlpool(&self) -> String {
+        self.accounts
+            .as_ref()
+            .map(|a| a.whirlpool.clone())
+            .unwrap_or_default()
+    }
+
+    fn position_authority(&self) -> String {
+        self.accounts
+            .as_ref()
+            .map(|a| a.position_authority.clone())
+            .unwrap_or_default()
+    }
+
+    fn amount_a(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_a_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_a_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn amount_b_post(&self) -> String {
+        self.instruction
+            .as_ref()
+            .and_then(|i| i.amount_b_post.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+
+    fn liquidity_amount(&self) -> String {
+        self.instruction
+            .as_ref()
+            .map(|i| i.liquidity_amount.clone())
+            .unwrap_or_else(|| ZERO_STRING.to_string())
+    }
+}

--- a/orca-whirlpool/src/utils.rs
+++ b/orca-whirlpool/src/utils.rs
@@ -1,25 +1,13 @@
 use substreams::scalar::BigInt;
-use substreams_solana::block_view::InstructionView;
-use substreams_solana_program_instructions::token_instruction_2022::TokenInstruction;
 
-#[allow(deprecated)]
-pub fn get_transfer_amount(instruction: Option<&InstructionView>) -> Option<String> {
-    instruction?;
+use crate::constants::ZERO_STRING;
 
-    let data = instruction.unwrap().data();
-
-    match TokenInstruction::unpack(data).unwrap() {
-        TokenInstruction::Transfer { amount } => Some(amount.to_string()),
-        _ => None,
-    }
-}
-
-pub fn balance_difference(
+pub(crate) fn balance_difference(
     pre_balance: Option<String>,
     post_balance: Option<String>,
 ) -> Option<String> {
-    let pre_balance_value = pre_balance.unwrap_or("0".to_string());
-    let post_balance_value = post_balance.unwrap_or("0".to_string());
+    let pre_balance_value = pre_balance.unwrap_or(ZERO_STRING.to_string());
+    let post_balance_value = post_balance.unwrap_or(ZERO_STRING.to_string());
 
     let pre_balance_bigint = BigInt::try_from(&pre_balance_value).unwrap();
     let post_balance_bigint = BigInt::try_from(&post_balance_value).unwrap();


### PR DESCRIPTION
# Summary
This PR introduces significant enhancements to the Orca Whirlpool Substream, focusing on adding new snapshot entities. 
Here's a summary of the key changes:

### Key Changes

- Introduced `DepositInstruction`, `WithdrawInstruction`, and `SwapInstruction` traits
- Updated `map_deposits`, `map_withdraws`, and `process_swap` functions to use these traits
- Added `process_swap` and `process_two_hop_swap` functions
- Introduced V2 versions for both swap and two-hop swap instructions
- Added `process_decrease_liquidity` and `process_increase_liquidity` functions
- Introduced V2 versions for both increase and decrease liquidity instructions

### Deployment
ID: `QmQgqNa3caw5hcjDjGYW34TBtSw5EA42uFLidHFNUaU1HW`([okgraph](https://okgraph.xyz/?q=QmQgqNa3caw5hcjDjGYW34TBtSw5EA42uFLidHFNUaU1HW))

**[Published Deployment](https://thegraph.com/explorer/subgraphs/Gktutwo5CMRA9LmrDHi4yH3Msfe2T5tp9RBeLVPgCH4b?view=Query&chain=arbitrum-one)**